### PR TITLE
ui-fixes-for-demo-20200405 - various UI fixes, which include

### DIFF
--- a/opentreemap/treemap/js/src/mapPage/addTreeMode.js
+++ b/opentreemap/treemap/js/src/mapPage/addTreeMode.js
@@ -11,13 +11,15 @@ var $ = require('jquery'),
 var activateMode = _.identity,
     deactivateMode = _.identity,
     STEP_LOCATE = 0,
-    STEP_DETAILS = 1,
-    STEP_FINAL = 2;
+    STEP_PHOTO = 1,
+    STEP_DETAILS = 2,
+    STEP_FINAL = 3;
 
 function init(options) {
     var $sidebar = $(options.sidebar),
         $speciesTypeahead = U.$find('#add-tree-species-typeahead', $sidebar),
         $summaryHead = U.$find('.summaryHead', $sidebar),
+        $isEmptySite = U.$find('#is-empty-site', $sidebar),
         $summarySubhead = U.$find('.summarySubhead', $sidebar),
         typeahead = otmTypeahead.create(options.typeahead),
         clearEditControls = function() {
@@ -55,9 +57,13 @@ function init(options) {
 
     function aTreeFieldIsSet() {
         var data = manager.getFormData();
-        return _.some(data, function (value, key) {
+        var treeValueSet = _.some(data, function (value, key) {
             return key && key.indexOf('tree') === 0 && value;
         });
+
+        // either we have a tree value set, or we have not explicitly
+        // said this is an empty site
+        return treeValueSet || !$isEmptySite.is(":checked");
     }
 
     // In case we're adding another tree, make user move the marker

--- a/opentreemap/treemap/js/src/mapPage/modes.js
+++ b/opentreemap/treemap/js/src/mapPage/modes.js
@@ -209,7 +209,7 @@ function getSpeciesTypeaheadOptions(idPrefix) {
         hidden: "#" + idPrefix + "-hidden",
         reverse: "id",
         forceMatch: true,
-        minLength: 1
+        minLength: 0
     };
 }
 

--- a/opentreemap/treemap/templates/treemap/field/species_div.html
+++ b/opentreemap/treemap/templates/treemap/field/species_div.html
@@ -13,6 +13,10 @@
     <label>{% trans "Species" %}</label>
     <div>
       {% include "treemap/field/species_typeahead.html" %}
+
+    <input name="is_empty_site"
+        id="is-empty-site"
+        type="checkbox" /> <label for="is-empty-site">Is Empty Site</label>
     </div>
     <div class="alert alert-danger text-danger"
         style="display: none;"

--- a/opentreemap/treemap/templates/treemap/map-add-tree.html
+++ b/opentreemap/treemap/templates/treemap/map-add-tree.html
@@ -1,12 +1,39 @@
 {% load form_extras %}
 {% load i18n %}
 
-{% with nsteps=3 %}
+{% with nsteps=4 %}
 <div class="sidebar-inner">
     <a href="javascript:;" class="close cancelBtn small hidden-xs">×</a>
     <h3>{% trans "Add a Tree" %}</h3>
     <div class="add-step-container" id="add-tree-container">
         {% include "treemap/partials/step_set_location.html" with first=True feature_name="tree" %}
+
+        <div class="add-step">
+            <div class="add-step-header">
+                {% trans "Add tree photos" %}
+                <a href="javascript:;" class="close cancelBtn small visible-xs-block">×</a>
+            </div>
+            <div class="add-step-content">
+                <table class="table table-hover">
+                    <tbody>
+                        <tr>
+                            <td>Add photo of tree shape</td>
+                            <td><button class="btn">Upload</button></td>
+                        </tr>
+                        <tr>
+                            <td>Add photo of tree leaf</td>
+                            <td><button class="btn">Upload</button></td>
+                        </tr>
+                        <tr>
+                            <td>Add photo of tree bark</td>
+                            <td><button class="btn">Upload</button></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            {% include 'treemap/partials/step_controls.html' %}
+        </div>
+
         <div class="add-step">
             <div class="add-step-header">
                 {% trans "Add species and additional info" %}
@@ -16,12 +43,13 @@
                 <form id="add-tree-form" onsubmit="return false;">
                     {# The "add-tree-species" label is used as an id prefix in "species_ul.html" #}
                     {% create "add-tree-species" from "Tree.species" in request.instance withtemplate "treemap/field/species_div.html" %}
+
                     {% trans "Trunk Diameter" as diameter %}
                     {% create diameter from "Tree.diameter" in request.instance withtemplate "treemap/field/diameter_div.html" %}
 
                 {% for group in field_groups %}
                     {% if group.model == "plot" %}
-                        <h3>{% trans "Plot Information" %}</h3>
+                        <h3>{% trans "Planting Site Information" %}</h3>
                         <table class="table table-hover">
                             <tbody>
                             {% for tuple in group.fields %}

--- a/opentreemap/treemap/templates/treemap/partials/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/partials/plot_detail.html
@@ -18,7 +18,7 @@
 
     <!-- Ecosystem Benefits -->
     <div id="ecobenefits">
-        <h3>{% trans "Yearly Ecosystem Services" %}</h3>
+        <h3>{% trans "Annual Ecosystem Services" %}</h3>
         {% if request.instance_supports_ecobenefits %}
             {% include "treemap/partials/plot_eco.html" %}
         {% else %}


### PR DESCRIPTION
    - Minor renames
    - Additional step as placeholder for adding photos of different
labels
    - Typeahead for species is now a dropdown as well
    - Species is required, unless the missing site is explicitly set